### PR TITLE
Fixed broken links and pinned libc version

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -26,7 +26,7 @@ jobs:
           cargo update -p serde_json --precise=1.0.138
           cargo update -p chrono --precise=0.4.23
           cargo update -p num-traits --precise=0.2.18
-          cargo update -p libc --precise=0.2.171
+          cargo update -p libc --precise=0.2.172
           cargo update -p httpdate --precise=1.0.2
           cargo test
           cargo test --features "json-using-serde proxy punycode"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # async-minreq
 [![Crates.io](https://img.shields.io/crates/d/async-minreq.svg)](https://crates.io/crates/async-minreq)
-<!-- [![Documentation](https://docs.rs/minreq/badge.svg)](https://docs.rs/minreq) -->
+[![Documentation](https://img.shields.io/docsrs/async_minreq)](https://docs.rs/async_minreq/latest/async_minreq/)
 ![Unit tests](https://github.com/BEULAHEVANJALIN/async-minreq/actions/workflows/unit-tests.yml/badge.svg)
 ![MSRV](https://github.com/BEULAHEVANJALIN/async-minreq/actions/workflows/msrv.yml/badge.svg)
 
@@ -16,7 +16,7 @@ Note: some of the dependencies of this crate (especially `serde` and
 the various `https` libraries) are a lot more complicated than this
 library, and their impact on executable size reflects that.
 
-## [Documentation](https://docs.rs/async-minreq)
+## [Documentation](https://docs.rs/async_minreq/latest/async_minreq/)
 
 ## Minimum Supported Rust Version (MSRV)
 


### PR DESCRIPTION
Just fixed broken links, which are now live after publishing the crate.
Also if you could provide your username on crate.io, so I could add you as owner of the crate.

Published crate [link](https://crates.io/crates/async_minreq)